### PR TITLE
docs: fix install instructions (package not yet on PyPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Corrected the README installation section: `pip install gen-fraud-graph` fails because the package is not yet published to PyPI, so the docs now lead with the from-source install (`uv pip install -e`) and note that the PyPI release is pending.
+
 ## [0.1.0] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,24 +49,30 @@ The generator creates three types of data:
 
 ### Installation
 
-```bash
-pip install gen-fraud-graph
-```
+> **Note:** `gen-fraud-graph` is not yet published to PyPI, so `pip install gen-fraud-graph` will fail with `No matching distribution found`. Until the first PyPI release, install from source as shown below. The PyPI badge above is pre-provisioned for the planned release.
 
-With optional embedding providers:
-```bash
-pip install 'gen-fraud-graph[local]'    # SentenceTransformers (local model)
-pip install 'gen-fraud-graph[openai]'   # OpenAI API embeddings
-pip install 'gen-fraud-graph[all]'      # Everything including dev tools
-```
-
-Or from source using [uv](https://github.com/astral-sh/uv):
+Install from source using [uv](https://github.com/astral-sh/uv):
 ```bash
 git clone https://github.com/SantanderAI/gen-fraud-graph.git
 cd gen-fraud-graph
 uv venv && source .venv/bin/activate
 uv pip install -e '.[dev]'
 ```
+
+With optional embedding providers (from the cloned source directory):
+```bash
+uv pip install -e '.[local]'    # SentenceTransformers (local model)
+uv pip install -e '.[openai]'   # OpenAI API embeddings
+uv pip install -e '.[all]'      # Everything including dev tools
+```
+
+If you prefer plain `pip` over `uv`, the source install works the same way:
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e '.[dev]'
+```
+
+Once the package is published, `pip install gen-fraud-graph` will be the recommended path.
 
 ### CLI Usage
 


### PR DESCRIPTION
# docs: fix install instructions (package is not on PyPI yet)

## Summary

The README's Quick Start tells users to run `pip install gen-fraud-graph` as the
primary install path, but that package is not published on PyPI yet, so the command
fails for anyone following the docs. This PR replaces the failing command with the
from-source install path the project already documents (`uv pip install -e`), adds a
plain-`pip` source variant, and adds an honest note that the PyPI release is still
pending. No code changes.

## Reproduction (clean environment)

A fresh virtual environment with only PyPI configured cannot resolve the package:

```console
$ uv venv --python 3.12 /tmp/clean
$ /tmp/clean/bin/python -m pip install gen-fraud-graph
ERROR: Could not find a version that satisfies the requirement gen-fraud-graph (from versions: none)
ERROR: No matching distribution found for gen-fraud-graph
```

The same resolution failure via uv:

```console
$ uv pip install gen-fraud-graph
  × No solution found when resolving dependencies:
  ╰─▶ Because gen-fraud-graph was not found in the package registry and you
      require gen-fraud-graph, we can conclude that your requirements are
      unsatisfiable.
```

This is consistent with the repo state: `release.yml` publishes to PyPI on a GitHub
Release, and no `0.1.0` release/tag has been published yet, so there is no
distribution to install.

## Changes

- `README.md`: the Installation section now leads with the from-source `uv pip install -e '.[dev]'`
  path, lists the optional extras (`local`, `openai`, `all`) as source installs, adds a
  plain-`pip` source variant, and carries a short note that `pip install gen-fraud-graph`
  will only work once the package is published. The PyPI badge is left in place (it is
  pre-provisioned for the planned release).
- `CHANGELOG.md`: one-line entry under `[Unreleased] / Fixed`.

## Notes

- Minimal, docs-only, no behaviour change.
- Per `CONTRIBUTING.md`, this repo requires signing the Santander Contributor License
  Agreement (CLA) before merge. The CLA Assistant workflow (`.github/workflows/cla.yml`)
  records signatures under `.cla-signatures/`. I will sign the CLA when prompted on the PR.
