### PR TITLE
security: scope CLA workflow token permissions to job level

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,17 +16,19 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-# contents: write is required so the bot can commit the signature file back.
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+# contents: write is required so the bot can commit the signature file back;
+# all permissions are granted at job level only (top-level default: none).
+permissions: {}
 
 jobs:
   cla:
     name: CLA Assistant
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
     if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
     steps:
       - name: CLA Assistant


### PR DESCRIPTION
## What

Moves the four token scopes CLA Assistant Lite needs (`actions`, `contents`, `pull-requests`, `statuses`) from workflow level to the `cla` job, and sets the top-level default to none (`permissions: {}`).

## Why

Least privilege for a `pull_request_target` workflow: same effective permissions today (single job), but nothing is inherited by future jobs. Addresses the OpenSSF Scorecard Token-Permissions findings for this workflow.

## Verification

After merge, commenting `recheck` on an open external PR re-runs the CLA check from `main`, confirming the bot still works with job-level permissions.