### PR TITLE
ci: attach SBOM (SPDX + CycloneDX) to every release

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,36 @@
+# Generates a Software Bill of Materials for each published release and
+# attaches it as release assets in both standard formats (SPDX + CycloneDX).
+# Manual runs (workflow_dispatch) upload the SBOMs as workflow artifacts only.
+name: SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sbom:
+    name: Generate and attach SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # upload release assets
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          format: spdx-json
+          output-file: ${{ github.event.repository.name }}-${{ github.ref_name }}.spdx.json
+          artifact-name: ${{ github.event.repository.name }}-${{ github.ref_name }}.spdx.json
+          upload-release-assets: ${{ github.event_name == 'release' }}
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          format: cyclonedx-json
+          output-file: ${{ github.event.repository.name }}-${{ github.ref_name }}.cdx.json
+          artifact-name: ${{ github.event.repository.name }}-${{ github.ref_name }}.cdx.json
+          upload-release-assets: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
## What

Adds a `sbom.yml` workflow that, on every published release, generates a Software Bill of Materials with syft (`anchore/sbom-action`, SHA-pinned) in **SPDX JSON** and **CycloneDX JSON**, and attaches both as release assets. `workflow_dispatch` runs upload them as workflow artifacts instead (verification path).

## Why

Consumers can audit exactly what ships in each version. Complements GitHub's on-demand dependency-graph SBOM export (which reflects current `main`, not a given release).

## Verification

Manual dispatch on `main` produces valid SPDX/CycloneDX documents as artifacts; the release path activates on the next published release.