### PR TITLE
docs: add usage, trademark and security disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ To report a security vulnerability, please follow the process described in [SECU
 
 ---
 
+## Disclaimer
+
+This software is an open source project from the **Santander AI Lab**, provided **"as is"** under its [license](LICENSE), without warranties or conditions of any kind. It is **not an official Banco Santander product or service**, carries no commitment of production support, and does not constitute financial, legal or professional advice.
+
+"Santander" and its logo are registered trademarks of **Banco Santander, S.A.** The project license does not grant any right to use them beyond factual attribution.
+
+If you believe you have found a security vulnerability, follow our [security policy](https://github.com/SantanderAI/.github/blob/main/SECURITY.md) — do not open a public issue. You are responsible for assessing the suitability of this software for your use case and for keeping your own deployments up to date.
+
 ## License
 
 This project is licensed under the Apache License 2.0 — see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Adds a standard **Disclaimer** section covering:

- "as is" provision under the project license; not an official Banco Santander product or service; no production support commitment.
- Trademark notice: the license grants no rights over the Santander name/logo (reinforces Apache-2.0 §6 for non-lawyer readers).
- Security: route vulnerabilities through the org security policy instead of public issues.

Org-wide rollout (12 product repos + org profile). Part of the security controls plan (P4).